### PR TITLE
Fix numpy2 and scipy compatibility

### DIFF
--- a/pyva/coupling/junctions.py
+++ b/pyva/coupling/junctions.py
@@ -1214,7 +1214,7 @@ class LineJunction(Junction) :
             
             #Integral in wavenumber space instead of angle requires the division be the in-field wavenumber
             for i_wave,i_type in enumerate(i_out_wave):
-                tau[i_wave,ifreq] = integrate.trapz(taus[i_wave,:],kx)/k_in
+                tau[i_wave,ifreq] = integrate.trapezoid(taus[i_wave,:],kx)/k_in
 
         if Signal:
                         
@@ -1387,7 +1387,7 @@ class LineJunction(Junction) :
                 taus = self.transmission_wavenumber_langley(om,kx,i_sys,i_in_wave,i_out_wave,Signal=False)
                         
             for i_o_wave,i_type in enumerate(i_out_wave):
-                etas[i_o_wave,ifreq] = fak1[ifreq]/modal_dens*integrate.trapz(taus[i_o_wave,:],kx)
+                etas[i_o_wave,ifreq] = fak1[ifreq]/modal_dens*integrate.trapezoid(taus[i_o_wave,:],kx)
                 
                 
 
@@ -2395,5 +2395,3 @@ class SemiInfiniteFluid(AreaJunction):
         """
         eta = self.CLF_fluid_fluid(omega)
         return eta
-
-    

--- a/pyva/models.py
+++ b/pyva/models.py
@@ -1007,9 +1007,9 @@ class TMmodel:
         
         # create besselmatrix with rows for distance and coloums for kx 
         J0 = scl.j0(distances.reshape(-1,1) @ kx.reshape(1,-1) )
-        D11 = fak*integrate.trapz(_D[0,0,:].data.flatten()*J0*kx,kx)
-        D12 = fak*integrate.trapz(_D[0,1,:].data.flatten()*J0*kx,kx)
-        D22 = fak*integrate.trapz(_D[1,1,:].data.flatten()*J0*kx,kx) # ,axis = 1
+        D11 = fak*integrate.trapezoid(_D[0,0,:].data.flatten()*J0*kx,kx)
+        D12 = fak*integrate.trapezoid(_D[0,1,:].data.flatten()*J0*kx,kx)
+        D22 = fak*integrate.trapezoid(_D[1,1,:].data.flatten()*J0*kx,kx) # ,axis = 1
         
         return (D11,D12,D22)
         
@@ -1371,7 +1371,7 @@ class TMmodel:
                 tau_kx = self.transmission_coefficient(om,kx_,fluids).ydata
             #remove nans
             tau_kx[np.isnan(tau_kx)] = 0.
-            tau_diffuse[ix] = 2*integrate.trapz(tau_kx*np.sin(theta_)*np.cos(theta_), theta_)/denom
+            tau_diffuse[ix] = 2*integrate.trapezoid(tau_kx*np.sin(theta_)*np.cos(theta_), theta_)/denom
 
         if uf.isscalar(omega):
             return tau_diffuse[0]

--- a/pyva/properties/materialClasses.py
+++ b/pyva/properties/materialClasses.py
@@ -1392,7 +1392,7 @@ class PoroElasticMat(EquivalentFluid):
     def __init__(self,solid_mat,\
                       flow_res,porosity,tortuosity,length_visc,length_therm,limp = False,\
                       c0=343.,rho0=1.23,dynamic_viscosity=1.84e-5,kappa = 1.4, \
-                      Cp=1005.1, heat_conductivity = 0.0257673 , Ks = np.Inf):
+                      Cp=1005.1, heat_conductivity = 0.0257673 , Ks = np.inf):
         """
         Construcutor of equivalent fluid class.
         
@@ -1774,5 +1774,3 @@ class PoroElasticMat(EquivalentFluid):
         Z = -1j*(Zs1*Zf2*mu2-Zs2*Zf1*mu1)/D
         
         return Z
-
-    

--- a/pyva/properties/structuralPropertyClasses.py
+++ b/pyva/properties/structuralPropertyClasses.py
@@ -938,7 +938,7 @@ class PlateProp:
             tau_kx[tau_kx<0] = 0.
 
             #tau[ifreq],prec = integrate.quad(f, 0, theta_max)
-            tau[ifreq] = integrate.trapz(tau_kx*np.sin(theta_)*np.cos(theta_), theta_)/denom
+            tau[ifreq] = integrate.trapezoid(tau_kx*np.sin(theta_)*np.cos(theta_), theta_)/denom
 
         return tau  
         

--- a/pyva/systems/structure2Dsystems.py
+++ b/pyva/systems/structure2Dsystems.py
@@ -575,7 +575,7 @@ class Structure2DSystem(SEAsys.SEA_system):
             k_x  = k_B[ifreq]*np.sin(phi)
             sigs = ar.radiation_efficiency_leppington(om, k_x, k_y, self.Lx, self.Ly,simple_muGT1=simple_muGT1) 
                 
-            sigma[ifreq] = 2/np.pi*integrate.trapz(sigs,phi)
+            sigma[ifreq] = 2/np.pi*integrate.trapezoid(sigs,phi)
             
         return sigma
             


### PR DESCRIPTION
Hello Alexander,

currently `pyva` is not working with Numpy 2 but fortunately there is only one line affected as it is stated in this error:

```python

AttributeError('`np.Inf` was removed in the NumPy 2.0 release. Use `np.inf` instead.')
  File "/home/user/.uvenv/dev/lib/python3.12/site-packages/pyva/models.py", line 11, in <module>
    import pyva.properties.materialClasses as matC
  File "/home/user/.uvenv/dev/lib/python3.12/site-packages/pyva/properties/materialClasses.py", line 1368, in <module>
    class PoroElasticMat(EquivalentFluid):
  File "/home/user/.uvenv/dev/lib/python3.12/site-packages/pyva/properties/materialClasses.py", line 1395, in PoroElasticMat
    Cp=1005.1, heat_conductivity = 0.0257673 , Ks = np.Inf):
                                                    ^^^^^^
  File "/home/user/.uvenv/dev/lib/python3.12/site-packages/numpy/__init__.py", line 400, in __getattr__
```

As far as I could trace, `np.inf` [is available at least from Numpy 1.15](https://numpy.org/doc/1.15/reference/constants.html?highlight=inf#numpy.inf) so the change I'm proposing it's ok since the dependencies in the `pyproject.toml` is `numpy>=1.20.2`.

I've also checked with `ruffus` as it is recommended [in the Numpy docs](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#ruff-plugin) and only found this problem, so there is only one compatibility error.

Kind regards,

Felipe

PS: Output of `ruffus` if you are curious:

```python

pyva/properties/materialClasses.py:1321:71: NPY201 [*] `np.Inf` will be removed in NumPy 2.0. Use `numpy.inf` instead.
     |
1319 |                       flow_res,porosity,tortuosity,length_visc,length_therm,limp = False,\
1320 |                       c0=343.,rho0=1.23,dynamic_viscosity=1.84e-5,kappa = 1.4, \
1321 |                       Cp=1005.1, heat_conductivity = 0.0257673 , Ks = np.Inf):
     |                                                                       ^^^^^^ NPY201
1322 |         """
1323 |         Construcutor of equivalent fluid class.
     |
     = help: Replace with `numpy.inf````