### PR TITLE
scipy: simps -> simpson

### DIFF
--- a/pyva/models.py
+++ b/pyva/models.py
@@ -1260,7 +1260,7 @@ class TMmodel:
             #remove nans
             abs_kx[np.isnan(abs_kx)] = 0.
             denom = np.sin(theta_max)**2
-            abs_diffuse[ix] = 2*integrate.simps(abs_kx*np.sin(theta_)*np.cos(theta_), theta_)/denom
+            abs_diffuse[ix] = 2*integrate.simpson(abs_kx*np.sin(theta_)*np.cos(theta_), theta_)/denom
 
         if uf.isscalar(omega):
             return abs_diffuse[0]

--- a/pyva/properties/materialClasses.py
+++ b/pyva/properties/materialClasses.py
@@ -522,14 +522,14 @@ class Fluid:
                 abs_theta = self.absorption(omega,z,theta_)
                 #remove nans
                 abs_theta[np.isnan(abs_theta)] = 0.
-                alpha = 2*integrate.simps(abs_theta*np.sin(theta_)*np.cos(theta_), theta_)/denom
+                alpha = 2*integrate.simpson(abs_theta*np.sin(theta_)*np.cos(theta_), theta_)/denom
         else:
             alpha = np.zeros(omega.shape)
             for i_,om_ in enumerate(omega):
                 abs_theta = self.absorption(om_,z,theta_)
                 #remove nans
                 abs_theta[np.isnan(abs_theta)] = 0.
-                alpha[i_] = 2*integrate.simps(abs_theta*np.sin(theta_)*np.cos(theta_), theta_)/denom
+                alpha[i_] = 2*integrate.simpson(abs_theta*np.sin(theta_)*np.cos(theta_), theta_)/denom
         
         return alpha
     


### PR DESCRIPTION
Hello,

Following the discussion on https://github.com/minipief/pyva/issues/10, I've noticed that running [this example](https://pyva.eu/infinite_layer.html#absorber-design) I got an error with the most recent version of scipy (1.15.1) installed on my system. You can see it here:

```python
AttributeError                            Traceback (most recent call last)
Cell In[1], line 42
     39 TMM_fibre_20      = mds.TMmodel((fibre_20cm,))
     40 TMM_perf_fibre_20 = mds.TMmodel((perforate, fibre_10cm,))
---> 42 alpha_fibre_10      = TMM_fibre_10.absorption_diffuse(omega,theta_max=np.pi/2,signal = False)
     43 alpha_fibre_20      = TMM_fibre_20.absorption_diffuse(omega,theta_max=np.pi/2,signal = False)
     44 alpha_perf_fibre_10 = TMM_perf_fibre_20.absorption_diffuse(omega,theta_max=np.pi/2,signal = False)

File ~/.uvenv/dev/lib/python3.12/site-packages/pyva/models.py:1263, in TMmodel.absorption_diffuse(self, omega, theta_max, theta_step, in_fluid, ID, boundary_condition, allard, signal, out_fluid)
   1261     abs_kx[np.isnan(abs_kx)] = 0.
   1262     denom = np.sin(theta_max)**2
-> 1263     abs_diffuse[ix] = 2*integrate.simps(abs_kx*np.sin(theta_)*np.cos(theta_), theta_)/denom
   1265 if uf.isscalar(omega):
   1266     return abs_diffuse[0]

AttributeError: module 'scipy.integrate' has no attribute 'simps'
```

Apparently, there was a warning deprecation for some time and in scipy 1.14.0 `scipy.integrate.simps` was removed in favour of `scipy.integrate.simpson` (https://docs.scipy.org/doc/scipy/release/1.14.0-notes.html#expired-deprecations). Since `simpson` was introduced in scipy 1.11.0 (around mid 2023) I think it could be safe to update from `simps` to `simpson`.

However, this would potentially be a change for other dependencies as well. According to [Numpy's support table](https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table) we should point to at least these versions:

| Date | Python version | Numpy version |
|--------|--------|--------|
|Apr 04, 2025 | 3.11+ | 1.25+ |

So, this could affect the configuration in `pyproject.toml` and right now I'm not pushing a change in that file.

Alexander, what do you think if we update the required dependencies versions? I don't know different setups and if they are updated or not but supporting old versions doesn't seem to be any good.

Best regards,

Felipe Raimann